### PR TITLE
fix: 修正淘礼金创建接口错误判断逻辑

### DIFF
--- a/tbopensdk/response/tbkdgvegastljcreate/tbkdgvegastljcreate.go
+++ b/tbopensdk/response/tbkdgvegastljcreate/tbkdgvegastljcreate.go
@@ -22,13 +22,21 @@ func (t *Response) WrapResult(result string) {
 		t.ErrorResponse.Code = -1
 		t.ErrorResponse.Msg = unmarshal.Error()
 	} else {
-		if t.CreateResponse.Result.MsgCode != "" {
-			t.ErrorResponse.Code = -2
-			t.ErrorResponse.Msg = fmt.Sprintf("MsgCode:%s MsgInfo:%s", t.CreateResponse.Result.MsgCode, t.CreateResponse.Result.MsgInfo)
-			t.ErrorResponse.SubCode = t.CreateResponse.Result.MsgCode
-			t.ErrorResponse.SubMsg = t.CreateResponse.Result.MsgInfo
-			t.ErrorResponse.RequestID = t.CreateResponse.RequestID
+		// 先判断 Success 是否为 false
+		if !t.CreateResponse.Result.Success {
+			// 只有 Success=false 时才认为是失败
+			if t.CreateResponse.Result.MsgCode != "" {
+				t.ErrorResponse.Code = -2
+				t.ErrorResponse.Msg = fmt.Sprintf("MsgCode:%s MsgInfo:%s", t.CreateResponse.Result.MsgCode, t.CreateResponse.Result.MsgInfo)
+				t.ErrorResponse.SubCode = t.CreateResponse.Result.MsgCode
+				t.ErrorResponse.SubMsg = t.CreateResponse.Result.MsgInfo
+				t.ErrorResponse.RequestID = t.CreateResponse.RequestID
+			} else {
+				t.ErrorResponse.Code = -2
+				t.ErrorResponse.Msg = "创建淘礼金失败"
+			}
 		} else if t.CreateResponse.Result.Model == nil || t.CreateResponse.Result.Model.SendURL == "" {
+			// Success=true 但数据不完整的情况
 			t.ErrorResponse.Code = -3
 			t.ErrorResponse.Msg = "用户无权创建淘礼金"
 			t.ErrorResponse.SubCode = "用户无权创建淘礼金"


### PR DESCRIPTION
## 问题描述

当前代码在判断接口调用是否成功时，仅通过  是否为空来判断，但实际上  即使在成功时也可能有值（如 "SUCCESS"、"0000" 等成功码）。

这导致成功的请求被误判为失败。

## 修复方案

修改判断逻辑，优先通过  字段来判断是否成功：

- 只有当  时才认为是失败
- 当  时，再检查  和  是否为空
- 当  但数据不完整时，返回 -3 错误码

## 测试

- 代码已通过 Go 编译检查
- 符合项目现有代码风格