### PR TITLE
fix: 补全 pdd.ddk.order.list.increment.get 订单字段

### DIFF
--- a/pddopensdk/response/pddddkorderlistincrementget/pddddkorderlistincrementget.go
+++ b/pddopensdk/response/pddddkorderlistincrementget/pddddkorderlistincrementget.go
@@ -5,13 +5,13 @@ import (
 	response2 "github.com/mimicode/tksdk/pddopensdk/response"
 )
 
-//pdd.ddk.order.list.increment.get（最后更新时间段增量同步推广订单信息）
+// pdd.ddk.order.list.increment.get（最后更新时间段增量同步推广订单信息）
 type Response struct {
 	response2.TopResponse
 	OrderListGetResponse OrderListGetResponse `json:"order_list_get_response"`
 }
 
-//解析输出结果
+// 解析输出结果
 func (t *Response) WrapResult(result string) {
 	unmarshal := json.Unmarshal([]byte(result), t)
 	//保存原始信息
@@ -30,30 +30,37 @@ type OrderListGetResponse struct {
 }
 
 type OrderList struct {
-	GoodsPrice            int64   `json:"goods_price"`
-	PromotionRate         int64   `json:"promotion_rate"`
-	Type                  int64   `json:"type"`
-	OrderStatus           int64   `json:"order_status"`
-	CatIDS                []int64 `json:"cat_ids"`
-	OrderCreateTime       int64   `json:"order_create_time"`
-	IsDirect              int64   `json:"is_direct"`
-	OrderGroupSuccessTime int64   `json:"order_group_success_time"`
-	OrderAmount           int64   `json:"order_amount"`
-	OrderModifyAt         int64   `json:"order_modify_at"`
-	AuthDuoID             int64   `json:"auth_duo_id"`
-	CPANew                int64   `json:"cpa_new"`
-	GoodsName             string  `json:"goods_name"`
-	BatchNo               string  `json:"batch_no"`
-	GoodsQuantity         int64   `json:"goods_quantity"`
-	GoodsID               int64   `json:"goods_id"`
-	CustomParameters      string  `json:"custom_parameters"`
-	GoodsThumbnailURL     string  `json:"goods_thumbnail_url"`
-	PromotionAmount       int64   `json:"promotion_amount"`
-	OrderPayTime          int64   `json:"order_pay_time"`
-	GroupID               float64 `json:"group_id"`
-	OrderStatusDesc       string  `json:"order_status_desc"`
-	OrderID               string  `json:"order_id"`
-	OrderSn               string  `json:"order_sn"`
-	PID                   string  `json:"p_id"`
-	ZsDuoID               int64   `json:"zs_duo_id"`
+	GoodsPrice            int64   `json:"goods_price"`              //单团价格，单位：分
+	PromotionRate         int64   `json:"promotion_rate"`           //佣金比例，千分比
+	Type                  int64   `json:"type"`                     //订单类型
+	OrderStatus           int64   `json:"order_status"`             //订单状态：0-已创建，1-已成团，2-确认收货，3-审核完成，4-已结算，5-已取消
+	CatIDS                []int64 `json:"cat_ids"`                  //商品类目ID列表
+	OrderCreateTime       int64   `json:"order_create_time"`        //订单创建时间，UNIX秒级时间戳
+	IsDirect              int64   `json:"is_direct"`                //是否直推：1-是，0-否
+	OrderGroupSuccessTime int64   `json:"order_group_success_time"` //成团时间，UNIX秒级时间戳
+	OrderAmount           int64   `json:"order_amount"`             //订单金额，单位：分
+	OrderModifyAt         int64   `json:"order_modify_at"`          //订单最后修改时间，UNIX秒级时间戳
+	AuthDuoID             int64   `json:"auth_duo_id"`              //授权多多客ID
+	CPANew                int64   `json:"cpa_new"`                  //CPA奖励金额
+	GoodsName             string  `json:"goods_name"`               //商品标题
+	BatchNo               string  `json:"batch_no"`                 //批次号
+	GoodsQuantity         int64   `json:"goods_quantity"`           //商品购买数量
+	GoodsID               int64   `json:"goods_id"`                 //商品ID
+	CustomParameters      string  `json:"custom_parameters"`        //自定义参数，用于区分推广渠道
+	GoodsThumbnailURL     string  `json:"goods_thumbnail_url"`      //商品缩略图URL
+	PromotionAmount       int64   `json:"promotion_amount"`         //佣金金额，单位：分
+	OrderPayTime          int64   `json:"order_pay_time"`           //订单支付时间，UNIX秒级时间戳
+	GroupID               float64 `json:"group_id"`                 //拼团ID
+	OrderStatusDesc       string  `json:"order_status_desc"`        //订单状态描述
+	OrderID               string  `json:"order_id"`                 //订单号
+	OrderSn               string  `json:"order_sn"`                 //子订单号
+	PID                   string  `json:"p_id"`                     //推广位ID
+	ZsDuoID               int64   `json:"zs_duo_id"`                //招商多多客ID
+	FailReason            string  `json:"fail_reason"`              //订单失效原因
+	GoodsSign             string  `json:"goods_sign"`               //商品签名（GoodsID + "_" + 拼团ID）
+	MallName              string  `json:"mall_name"`                //店铺名称
+	OrderReceiveTime      int64   `json:"order_receive_time"`       //确认收货时间，UNIX秒级时间戳
+	OrderSettleTime       int64   `json:"order_settle_time"`        //订单结算时间，UNIX秒级时间戳
+	OrderVerifyTime       int64   `json:"order_verify_time"`        //订单审核（结算）时间，UNIX秒级时间戳
+	PlatformDiscount      int64   `json:"platform_discount"`        //平台补贴金额，单位：分
 }


### PR DESCRIPTION
## 背景

Fixes #5

用户反馈 `pdd.ddk.order.list.increment.get` 响应的 `OrderList` 结构体缺少字段，而平行的 `pdd.ddk.order.list.range.get` 接口（`pddddkorderlistrangeget`）中字段齐全。

## 改动

对照官方文档（https://jinbao.pinduoduo.com/third-party/api-detail?apiName=pdd.ddk.order.list.increment.get）与 `pddddkorderlistrangeget`，为 `OrderList` 补齐 7 个缺失字段：

| 字段 | json tag | 类型 | 说明 |
|------|----------|------|------|
| FailReason | `fail_reason` | string | 订单失效原因 |
| GoodsSign | `goods_sign` | string | 商品签名 |
| MallName | `mall_name` | string | 店铺名称 |
| OrderReceiveTime | `order_receive_time` | int64 | 确认收货时间 |
| OrderSettleTime | `order_settle_time` | int64 | 订单结算时间 |
| OrderVerifyTime | `order_verify_time` | int64 | 订单审核时间 |
| PlatformDiscount | `platform_discount` | int64 | 平台补贴金额（分） |

新增字段类型与 `pddddkorderlistrangeget` 保持一致。同时为 `OrderList` 的**全部 33 个字段**补充了中文注释。

## 校验

- [x] `gofmt` 通过
- [x] `go build ./...` 通过
- [x] `go vet ./pddopensdk/...` 通过