### PR TITLE
feat: 订单接口新增淘礼金ID(rights_id)查询支持 (#13)

### DIFF
--- a/tbopensdk/client_test.go
+++ b/tbopensdk/client_test.go
@@ -48,7 +48,9 @@ import (
 	"github.com/mimicode/tksdk/tbopensdk/response/tbkscinvitecodeget"
 	"github.com/mimicode/tksdk/tbopensdk/response/tbkscmaterialoptional"
 	"github.com/mimicode/tksdk/tbopensdk/response/tbkscoptimusmaterial"
+	"github.com/mimicode/tksdk/tbopensdk/response/tbkscorderdetailsget"
 	"github.com/mimicode/tksdk/tbopensdk/response/tbkscorderget"
+	"github.com/mimicode/tksdk/tbopensdk/response/tbkscorderrefundget"
 	"github.com/mimicode/tksdk/tbopensdk/response/tbkscpublisherinfoget"
 	"github.com/mimicode/tksdk/tbopensdk/response/tbkscpublisherinfosave"
 	"github.com/mimicode/tksdk/tbopensdk/response/tbkscshopconvert"
@@ -1391,6 +1393,82 @@ func Test_TbkScGeneralLinkParseRequest(t *testing.T) {
 		result := getResponse.(*taobaotbkscgenerallinkparse.Response)
 		//	{"tbk_sc_general_link_parse_response":{"data":{"material_url_list":{"material_url_list":[{"input_material_url":"￥wseKeQ8Eae9￥","link_info_dto":{"material_id":"NbKBdpOC5tnKr8bSZG7uRtB-rZ9xkXF2QOndGQgHv","material_type":1,"tk_biz_type":1,"tpwd_origin_url":"https:\/\/s.click.taobao.com\/t?e=m%3D2%26s%3D8K7Iml1vlFNw4vFB6t2Z2ueEDrYVVa64yK8Cckff7TVRAdhuF14FMR%2F63mr1MO9uRitN3%2FurF3yWZIHuAfb160WeA7w%2BGhevk8tDEZYjwO%2FQaJ1Uan6hrPJi%2FB4SdxHVax%2BJLOEMomOM%2BK42QxlTAPJ%2BQj1g5vIrDCfT%2B86ifnCi1jMNxDhLMmuCMDETpg3itthcQic1bk0jE%2BZg8s25eGYijWD1dZmigtPPK%2B%2BRUVKRLVxRpcORA%2FuLuj82LRyWkYa%2B6kEEIxim6p2ONLZUzc7AMx9cWAx%2BEiM%2FlSG%2FbZRi647CDvvranctQqHt5GY8C%2FdQeSX7Vr6uOLrdHTHPFeDQMZ%2FA7AEiREwvT%2B0IE%2F0hhQs2DjqgEA%3D%3D&union_lens=lensId%3ATAPI%401740494671%40213e71e2_0e9f_1953d910f7e_a95a%40026Z9vLsbPhnLYHoveqxgxtV&relationId=2145841445&un=f91ad7de04e6dc7e7a811649f8da3e26&share_crt_v=1&un_site=0&ut_sk=1.utdid_null_1740494671864.TaoPassword-Outside.taoketop&spm=a2159r.13376465.0.0&sp_tk=d3NlS2VROEVhZTk%3D&bxsign=tcdB9mQLEOO9LJIR5sdisW0a5j78Vr6yyI5W5rTyQwLLujpHijT5lhCyTcgcH-hdVNZCrEu8K4YKCc_gNTUE76r6OogPPt3ND42ZmA_YI17jMI&bc_fl_src=share-707651363197-1-0"}}]}},"request_id":"15qzhcg5s559e"}}
 		fmt.Println(result.Body)
+
+	}
+}
+
+func TestTbkScOrderDetailsGet(t *testing.T) {
+
+	//初始化TopClient
+	client := &TopClient{}
+	client.Init(appKey, appSecret, sessionKey)
+
+	//初始化请求接口信息
+	getRequest := &request2.TbkScOrderDetailsGetRequest{}
+	//查询开始时间，格式：yyyy-MM-dd HH:mm:ss
+	getRequest.AddParameter("start_time", "2026-06-10 17:22:28")
+	//查询结束时间，格式：yyyy-MM-dd HH:mm:ss
+	getRequest.AddParameter("end_time", "2026-06-10 19:22:28")
+	//查询时间类型：1-创建时间，2-支付时间，3-结算时间，4-更新时间
+	getRequest.AddParameter("query_type", "1")
+	//推广者角色类型：2-二方，3-三方
+	// getRequest.AddParameter("member_type", "2")
+	//淘客订单状态：12-付款，13-关闭，14-确认收货，3-结算成功，4-已退票，多个用英文逗号拼接
+	// getRequest.AddParameter("tk_status", "12")
+	//第几页
+	getRequest.AddParameter("page_no", "1")
+	//页大小，默认20，范围1-100
+	getRequest.AddParameter("page_size", "20")
+	//场景订单：1-常规订单，2-渠道订单，3-会员运营订单
+	getRequest.AddParameter("order_scene", "2")
+
+	//初始化结果类型
+	var getResponse DefaultResponse = &tbkscorderdetailsget.Response{}
+	//执行请求接口得到结果
+	err := client.Exec(getRequest, getResponse)
+	if err != nil {
+		t.Log(err)
+	} else {
+		result := getResponse.(*tbkscorderdetailsget.Response)
+
+		fmt.Println(result.TbkScOrderDetailsGetResponse.Data)
+
+	}
+}
+
+func TestTbkScOrderRefundGet(t *testing.T) {
+
+	//初始化TopClient
+	client := &TopClient{}
+	client.Init(appKey, appSecret, sessionKey)
+
+	//初始化请求接口信息
+	getRequest := &request2.TbkScOrderRefundGetRequest{}
+	//查询开始时间，格式：yyyy-MM-dd HH:mm:ss
+	getRequest.AddParameter("start_time", "2026-06-01 00:00:00")
+	//查询结束时间，格式：yyyy-MM-dd HH:mm:ss
+	getRequest.AddParameter("end_time", "2026-06-02 00:00:00")
+	//查询时间类型：1-退款时间（范围最大90天），2-结算时间（范围最大29天）
+	getRequest.AddParameter("query_type", "1")
+	//推广者角色类型：2-二方，3-三方
+	getRequest.AddParameter("member_type", "2")
+	//第几页
+	getRequest.AddParameter("page_no", "1")
+	//页大小，默认20，范围1-100
+	getRequest.AddParameter("page_size", "20")
+	//场景订单：1-常规订单，2-渠道订单，3-会员运营订单
+	getRequest.AddParameter("order_scene", "2")
+
+	//初始化结果类型
+	var getResponse DefaultResponse = &tbkscorderrefundget.Response{}
+	//执行请求接口得到结果
+	err := client.Exec(getRequest, getResponse)
+	if err != nil {
+		t.Log(err)
+	} else {
+		result := getResponse.(*tbkscorderrefundget.Response)
+
+		fmt.Println(result.TbkScOrderRefundGetResponse.Data)
 
 	}
 }

--- a/tbopensdk/request/tbkscorderrefundget.go
+++ b/tbopensdk/request/tbkscorderrefundget.go
@@ -1,0 +1,45 @@
+package request
+
+import (
+	"github.com/mimicode/tksdk/utils"
+	"net/url"
+)
+
+// taobao.tbk.sc.order.refund.get( 淘宝客-推广-全量售后退款订单查询 )
+// https://developer.alibaba.com/docs/api.htm?apiId=65381
+type TbkScOrderRefundGetRequest struct {
+	Parameters *url.Values //请求参数
+}
+
+func (tk *TbkScOrderRefundGetRequest) CheckParameters() {
+	utils.CheckNumber(tk.Parameters.Get("order_scene"), "order_scene")
+	utils.CheckNumber(tk.Parameters.Get("page_size"), "page_size")
+	utils.CheckNumber(tk.Parameters.Get("query_type"), "query_type")
+	utils.CheckNumber(tk.Parameters.Get("page_no"), "page_no")
+	utils.CheckNotNull(tk.Parameters.Get("start_time"), "start_time")
+	utils.CheckNumber(tk.Parameters.Get("member_type"), "member_type")
+	utils.CheckNotNull(tk.Parameters.Get("end_time"), "end_time")
+
+	// 可选参数检查
+	if tk.Parameters.Get("jump_type") != "" {
+		utils.CheckNumber(tk.Parameters.Get("jump_type"), "jump_type")
+	}
+}
+
+// 添加请求参数
+func (tk *TbkScOrderRefundGetRequest) AddParameter(key, val string) {
+	if tk.Parameters == nil {
+		tk.Parameters = &url.Values{}
+	}
+	tk.Parameters.Add(key, val)
+}
+
+// 返回接口名称
+func (tk *TbkScOrderRefundGetRequest) GetApiName() string {
+	return "taobao.tbk.sc.order.refund.get"
+}
+
+// 返回请求参数
+func (tk *TbkScOrderRefundGetRequest) GetParameters() url.Values {
+	return *tk.Parameters
+}

--- a/tbopensdk/response/tbkscorderdetailsget/tbkscorderdetailsget.go
+++ b/tbopensdk/response/tbkscorderdetailsget/tbkscorderdetailsget.go
@@ -65,6 +65,7 @@ type PublisherOrderDto struct {
 	PubSharePreFee                     string             `json:"pub_share_pre_fee"`
 	PubShareRate                       string             `json:"pub_share_rate"`
 	RefundTag                          int64              `json:"refund_tag"`
+	RightsId                           string             `json:"rights_id"` //淘礼金ID，每次创建的淘礼金有唯一的识别ID，可在订单中查询
 	SellerNick                         string             `json:"seller_nick"`
 	SellerShopTitle                    string             `json:"seller_shop_title"`
 	ServiceFeeDtoList                  *ServiceFeeDtoList `json:"service_fee_dto_list,omitempty"`

--- a/tbopensdk/response/tbkscorderrefundget/tbkscorderrefundget.go
+++ b/tbopensdk/response/tbkscorderrefundget/tbkscorderrefundget.go
@@ -1,0 +1,71 @@
+package tbkscorderrefundget
+
+import (
+	"encoding/json"
+	"github.com/mimicode/tksdk/tbopensdk/response"
+)
+
+// taobao.tbk.sc.order.refund.get( 淘宝客-推广-全量售后退款订单查询 )
+// https://developer.alibaba.com/docs/api.htm?apiId=65381
+type Response struct {
+	response.TopResponse
+	TbkScOrderRefundGetResponse TbkScOrderRefundGetResponse `json:"tbk_sc_order_refund_get_response"`
+}
+
+// 解析输出结果
+func (t *Response) WrapResult(result string) {
+	unmarshal := json.Unmarshal([]byte(result), t)
+	//保存原始信息
+	t.Body = result
+	//解析错误
+	if unmarshal != nil {
+		t.ErrorResponse.Code = -1
+		t.ErrorResponse.Msg = unmarshal.Error()
+	}
+}
+
+type TbkScOrderRefundGetResponse struct {
+	Data         Data   `json:"data"`           //返回数据
+	ResultCode   int64  `json:"result_code"`    //接口返回值信息，跟rpc架构保持一致
+	BizErrorDesc string `json:"biz_error_desc"` //业务错误信息
+	BizErrorCode int64  `json:"biz_error_code"` //业务错误码 101,102,103
+	ResultMsg    string `json:"result_msg"`     //返回信息
+}
+
+type Data struct {
+	Result        []PublisherRefundOrderDTO `json:"result"`         //真正的业务数据结构，售后退款订单明细列表
+	PrePage       int64                     `json:"pre_page"`       //上一页
+	NextPage      int64                     `json:"next_page"`      //下一页
+	PageNo        int64                     `json:"page_no"`        //页码
+	PageSize      int64                     `json:"page_size"`      //每页订单量
+	HasNext       bool                      `json:"has_next"`       //是否有下一页
+	PositionIndex string                    `json:"position_index"` //位点字段，由调用方原样传递
+	HasPre        bool                      `json:"has_pre"`        //是否有上一页
+}
+
+type PublisherRefundOrderDTO struct {
+	RefundSuitId               string `json:"refund_suit_id"`                 //维权编号，当前订单发生维权退款的编号（非淘宝订单编号），如订单发生多次维权则会产生多个维权编号
+	TbTradeParentId            string `json:"tb_trade_parent_id"`             //淘宝父订单编号（买家在淘宝后台显示的订单编号）
+	TbTradeId                  string `json:"tb_trade_id"`                    //淘宝子订单编号
+	TbTradeCreateTime          string `json:"tb_trade_create_time"`           //订单创建时间
+	EarningTime                string `json:"earning_time"`                   //订单结算时间
+	TkRefundTime               string `json:"tk_refund_time"`                 //维权创建时间
+	TkRefundSuitTime           string `json:"tk_refund_suit_time"`            //维权完成时间
+	ModifiedTime               string `json:"modified_time"`                  //订单更新时间
+	ItemTitle                  string `json:"item_title"`                     //商品标题
+	TkOrderRole                string `json:"tk_order_role"`                  //推广者角色（二方、三方）
+	RefundStatus               int64  `json:"refund_status"`                  //维权状态：4-维权创建，2-维权成功，3-维权失败，11-发生多次维权待处理，12/13-从淘客处补扣等待/成功，14/15-从卖家处补扣等待/成功
+	TbTradeFinishPrice         string `json:"tb_trade_finish_price"`          //结算金额（订单确认收货后的成交金额）
+	RefundFee                  string `json:"refund_fee"`                     //维权金额（买家申请维权退款的金额）
+	PubShareFee                string `json:"pub_share_fee"`                  //结算预估收入=结算金额*提成，以订单确认收货后的成交金额为基数预估的收入
+	TkCommissionFeeRefund      string `json:"tk_commission_fee_refund"`       //应退还佣金（不含技术服务费和渠道专项服务费）
+	TkSubsidyFeeRefund         string `json:"tk_subsidy_fee_refund"`          //应退还补贴（不含技术服务费和渠道专项服务费）
+	TkCommissionAlimmRefundFee string `json:"tk_commission_alimm_refund_fee"` //应退还佣金对应的技术服务费
+	TkSubsidyAlimmRefundFee    string `json:"tk_subsidy_alimm_refund_fee"`    //应退还补贴对应的技术服务费
+	TkCommissionAgentRefundFee string `json:"tk_commission_agent_refund_fee"` //应退还佣金对应的渠道专项服务费
+	TkSubsidyAgentRefundFee    string `json:"tk_subsidy_agent_refund_fee"`    //应退还补贴对应的渠道专项服务费
+	ShowReturnFee              string `json:"show_return_fee"`                //应退还预估收入：订单发生维权退款应退还的预估收入（佣金+补贴，含技术服务费和渠道专项服务费）
+	RelationId                 int64  `json:"relation_id"`                    //渠道关系id
+	SpecialId                  int64  `json:"special_id"`                     //会员关系id
+	RightsId                   string `json:"rights_id"`                      //淘礼金ID，每次创建的淘礼金有唯一的识别ID，可在订单中查询
+}


### PR DESCRIPTION
## 背景
实现 Issue #13：淘宝联盟订单接口新增淘礼金ID（rights_id）查询支持。

## 改动内容
### 1. `taobao.tbk.sc.order.details.get`（已存在，补全字段）
- `tbopensdk/response/tbkscorderdetailsget/tbkscorderdetailsget.go`：在 `PublisherOrderDto` 新增 `RightsId` 字段（`json:"rights_id"`）并补注释。

### 2. `taobao.tbk.sc.order.refund.get`（新建服务商版接口）
- 原仓库仅含推广者版 `taobao.tbk.order.refund.get`，服务商版不存在，故新建：
  - `tbopensdk/request/tbkscorderrefundget.go`：请求结构，`GetApiName` 返回 `taobao.tbk.sc.order.refund.get`。
  - `tbopensdk/response/tbkscorderrefundget/tbkscorderrefundget.go`：按官方文档（apiId=65381）结构建模，`PublisherRefundOrderDTO` 含 `rights_id` 及完整字段注释。

### 3. 测试
- `tbopensdk/client_test.go`：新增 `TestTbkScOrderDetailsGet` 与 `TestTbkScOrderRefundGet`，每个参数均附中文注释与取值说明。

## 校验
- `gofmt -w` 通过；`go build ./...` 通过；`go test -list` 确认新测试编译无误。

Closes #13